### PR TITLE
Add the gumCallerId paremeter to addToAudience and removeFromAudience

### DIFF
--- a/lib/criteo_api.js
+++ b/lib/criteo_api.js
@@ -238,7 +238,8 @@ class Criteo_API_Client extends API_Client {
                     'operation': 'add',
                     'identifierType': options.identifierType,
                     'identifiers': options.identifiers,
-                    'internalIdentifiers': internalIdentifiers
+                    'internalIdentifiers': internalIdentifiers,
+                    'gumCallerId': options.gumCallerId
                 }
             }
         };
@@ -271,7 +272,8 @@ class Criteo_API_Client extends API_Client {
                     'operation': 'remove',
                     'identifierType': options.identifierType,
                     'identifiers': options.identifiers,
-                    'internalIdentifiers': internalIdentifiers
+                    'internalIdentifiers': internalIdentifiers,
+                    'gumCallerId': options.gumCallerId
                 }
             }
         };


### PR DESCRIPTION
I've patched the lib to properly manage the gumCallerId as Thomas told me that it was mandatory and I don't want to restart from scratch.
--
Stéphane from  Commanders Act